### PR TITLE
Fix for duplicate symbol when using with with cordova-plugin-ble-central

### DIFF
--- a/src/ios/BLEPeripheralPlugin.m
+++ b/src/ios/BLEPeripheralPlugin.m
@@ -19,6 +19,13 @@
 #import "BLEPeripheralPlugin.h"
 #import <Cordova/CDV.h>
 
+static NSDictionary *dataToArrayBuffer(NSData* data) {
+    return @{
+             @"CDVType" : @"ArrayBuffer",
+             @"data" :[data base64EncodedStringWithOptions:0]
+             };
+}
+
 @interface BLEPeripheralPlugin() {
     NSDictionary *bluetoothStates;
 }
@@ -377,17 +384,6 @@
 
     return service;
 
-}
-
-#pragma mark - Helper Functions
-
-// Borrowed from Cordova messageFromArrayBuffer since Cordova doesn't handle NSData in NSDictionary
-id dataToArrayBuffer(NSData* data)
-{
-    return @{
-             @"CDVType" : @"ArrayBuffer",
-             @"data" :[data base64EncodedStringWithOptions:0]
-             };
 }
 
 @end


### PR DESCRIPTION
In order to avoid https://github.com/don/cordova-plugin-ble-peripheral/issues/1 it's better to have the C function declared as static